### PR TITLE
fix: added authentication token to parameters (MAPCO-5792)

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -13,6 +13,9 @@ paths:
       tags:
         - feedback
       summary: creates a new record of a chosen result from Geocoding
+      parameters:
+        - $ref: '#/components/parameters/token'
+        - $ref: '#/components/parameters/xApiKey'
       requestBody:
         content:
           application/json:
@@ -22,18 +25,60 @@ paths:
         '204':
           description: Feedback has been sent successfully
         '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
 components:
+  responses:
+    BadRequest:
+      description: Invalid Request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error'
+    Unauthorized:
+      description: Please provide a valid token
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error'
+    NotFound:
+      description: Resource Not Found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error'
+    Forbidden:
+      description: Token is not valid
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error'
+    InternalError:
+      description: Invalid Request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error'
+  parameters:
+    xApiKey:
+      name: x-api-key
+      in: header
+      description: JWT authentication token provided by our team
+      schema:
+        type: string
+    token:
+      name: token
+      in: query
+      description: JWT authentication token provided by our team
+      schema:
+        type: string
   schemas:
     error:
       type: object

--- a/src/feedback/controllers/feedbackController.ts
+++ b/src/feedback/controllers/feedbackController.ts
@@ -8,7 +8,7 @@ import { IFeedbackModel } from '../models/feedback';
 import { FeedbackManager } from '../models/feedbackManager';
 import { FeedbackResponse } from '../../common/interfaces';
 
-type CreateFeedbackHandler = RequestHandler<undefined, FeedbackResponse, IFeedbackModel>;
+export type CreateFeedbackHandler = RequestHandler<undefined, FeedbackResponse, IFeedbackModel>;
 
 @injectable()
 export class FeedbackController {
@@ -24,7 +24,8 @@ export class FeedbackController {
 
   public createFeedback: CreateFeedbackHandler = async (req, res, next) => {
     try {
-      const createdFeedback = this.manager.createFeedback(req.body);
+      const apiKey = (req.headers['x-api-key'] as string | undefined) ?? (req.query.token as string);
+      const createdFeedback = this.manager.createFeedback(req.body, apiKey);
       this.createdFeedbackCounter.add(1);
       return res.status(httpStatus.NO_CONTENT).json(await createdFeedback);
     } catch (error) {

--- a/tests/unit/feedback/models/feedbackModel.spec.ts
+++ b/tests/unit/feedback/models/feedbackModel.spec.ts
@@ -52,7 +52,7 @@ describe('FeedbackManager', () => {
       const feedbackRequest: IFeedbackModel = { request_id: requestId, chosen_result_id: chosenResultId, user_id: userId };
       (mockedRedis.get as jest.Mock).mockResolvedValue('{ "geocodingResponse": "completed" }');
 
-      const feedback = await feedbackManager.createFeedback(feedbackRequest);
+      const feedback = await feedbackManager.createFeedback(feedbackRequest, 'token');
 
       // expectation
       expect(feedback.requestId).toBe(requestId);
@@ -64,7 +64,7 @@ describe('FeedbackManager', () => {
 
     it('should not create feedback when user_id is not valid', async function () {
       const feedbackRequest: IFeedbackModel = { request_id: '417a4635-0c59-4b5c-877c-45b4bbaaac7a', chosen_result_id: 3, user_id: 'user1' };
-      const feedback = feedbackManager.createFeedback(feedbackRequest);
+      const feedback = feedbackManager.createFeedback(feedbackRequest, 'token');
 
       await expect(feedback).rejects.toThrow(BadRequestError);
     });
@@ -75,7 +75,7 @@ describe('FeedbackManager', () => {
         chosen_result_id: 3,
         user_id: 'user1@mycompany.net',
       };
-      const feedback = feedbackManager.createFeedback(feedbackRequest);
+      const feedback = feedbackManager.createFeedback(feedbackRequest, 'token');
 
       await expect(feedback).rejects.toThrow(NotFoundError);
     });
@@ -89,7 +89,7 @@ describe('FeedbackManager', () => {
       (mockedRedis.get as jest.Mock).mockResolvedValue('{ "geocodingResponse": "completed" }');
       mockProducer.send.mockRejectedValue(new Error('Kafka error'));
 
-      const feedback = feedbackManager.createFeedback(feedbackRequest);
+      const feedback = feedbackManager.createFeedback(feedbackRequest, 'token');
 
       await expect(feedback).rejects.toThrow(new Error('Kafka error'));
     });
@@ -102,7 +102,7 @@ describe('FeedbackManager', () => {
       };
       (mockedRedis.get as jest.Mock).mockRejectedValue(new Error('Redis error'));
 
-      const feedback = feedbackManager.createFeedback(feedbackRequest);
+      const feedback = feedbackManager.createFeedback(feedbackRequest, 'token');
 
       await expect(feedback).rejects.toThrow(new Error('Redis error'));
     });


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

Description:
When trying to authenticate a user using a token instead of an the `x-api-key` header, we got the error `unknown query parameter "token"`. We created the fix so we could add a token or an api-key