### PR TITLE
fix: liveness and redis subscriber configuration (MAPCO-6796)

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,34 +1,52 @@
-import { DependencyContainer, FactoryFunction } from 'tsyringe';
+import { DependencyContainer } from 'tsyringe';
 import { Logger } from '@map-colonies/js-logger';
+import { HealthCheck } from '@godaddy/terminus';
 import { RedisClient } from '../redis/index';
 import { SERVICES } from './constants';
 
-export const healthCheckFactory: FactoryFunction<void> = (container: DependencyContainer): void => {
-  const logger = container.resolve<Logger>(SERVICES.LOGGER);
-  const geocodingRedis = container.resolve<RedisClient>(SERVICES.GEOCODING_REDIS);
-  const ttlRedis = container.resolve<RedisClient>(SERVICES.TTL_REDIS);
+export const healthCheckFactory = (container: DependencyContainer): HealthCheck => {
+  return async (): Promise<void> => {
+    const logger = container.resolve<Logger>(SERVICES.LOGGER);
+    const geocodingRedis = container.resolve<RedisClient>(SERVICES.GEOCODING_REDIS);
+    const ttlRedis = container.resolve<RedisClient>(SERVICES.TTL_REDIS);
 
-  geocodingRedis
-    .ping()
-    .then(() => {
-      return;
-    })
-    .catch((error: Error) => {
-      logger.error({
-        message: `Healthcheck failed for GeocodingRedis.`,
-        error,
-      });
+    const promises: Promise<unknown>[] = [];
+
+    promises.push(
+      new Promise((resolve, reject) => {
+        geocodingRedis
+          .ping()
+          .then(() => {
+            resolve('Healthcheck passed for GeocodingRedis connection');
+          })
+          .catch((error: Error) => {
+            reject({
+              msg: `Healthcheck failed for GeocodingRedis.`,
+              error,
+            });
+          });
+      })
+    );
+    promises.push(
+      new Promise((resolve, reject) => {
+        ttlRedis
+          .ping()
+          .then(() => {
+            resolve('Healthcheck passed for TTLRedis connection');
+          })
+          .catch((error: Error) => {
+            reject({
+              msg: `Healthcheck failed for TTLRedis.`,
+              error,
+            });
+          });
+      })
+    );
+
+    await Promise.allSettled(promises).then((results) => {
+      results.forEach((msg) => logger.info({ msg }));
     });
 
-  ttlRedis
-    .ping()
-    .then(() => {
-      return;
-    })
-    .catch((error: Error) => {
-      logger.error({
-        message: `Healthcheck failed for GeocodingRedis.`,
-        error,
-      });
-    });
+    return Promise.resolve();
+  };
 };

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -44,7 +44,7 @@ export const healthCheckFactory = (container: DependencyContainer): HealthCheck 
     );
 
     await Promise.allSettled(promises).then((results) => {
-      results.forEach((msg) => logger.info({ msg }));
+      results.forEach((msg) => logger.debug({ msg }));
     });
 
     return Promise.resolve();

--- a/src/containerConfig.ts
+++ b/src/containerConfig.ts
@@ -2,6 +2,7 @@ import config from 'config';
 import { Producer } from 'kafkajs';
 import { getOtelMixin } from '@map-colonies/telemetry';
 import { trace, metrics as OtelMetrics } from '@opentelemetry/api';
+import { HealthCheck } from '@godaddy/terminus';
 import { DependencyContainer } from 'tsyringe/dist/typings/types';
 import jsLogger, { LoggerOptions } from '@map-colonies/js-logger';
 import { CleanupRegistry } from '@map-colonies/cleanup-registry';
@@ -94,7 +95,14 @@ export const registerExternalValues = async (options?: RegisterOptions): Promise
           }
         },
       },
-      { token: HEALTHCHECK, provider: { useFactory: healthCheckFactory } },
+      {
+        token: HEALTHCHECK,
+        provider: {
+          useFactory: (depContainer): HealthCheck => {
+            return healthCheckFactory(depContainer);
+          },
+        },
+      },
       {
         token: REDIS_SUB,
         provider: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,11 @@ void getApp()
   .then(({ app, container }) => {
     depContainer = container;
 
-    const logger = container.resolve<Logger>(SERVICES.LOGGER);
+    const logger = depContainer.resolve<Logger>(SERVICES.LOGGER);
     const server = createTerminus(createServer(app), {
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      healthChecks: { '/liveness': container.resolve(HEALTHCHECK) },
-      onSignal: container.resolve(ON_SIGNAL),
+      healthChecks: { '/liveness': depContainer.resolve(HEALTHCHECK) },
+      onSignal: depContainer.resolve(ON_SIGNAL),
     });
 
     server.listen(port, () => {
@@ -28,12 +28,12 @@ void getApp()
   })
   .catch(async (error: Error) => {
     const errorLogger =
-      depContainer?.isRegistered(SERVICES.LOGGER) == true
+      depContainer?.isRegistered(SERVICES.LOGGER) === true
         ? depContainer.resolve<Logger>(SERVICES.LOGGER).error.bind(depContainer.resolve<Logger>(SERVICES.LOGGER))
         : console.error;
     errorLogger({ msg: '😢 - failed initializing the server', err: error });
 
-    if (depContainer?.isRegistered(ON_SIGNAL) == true) {
+    if (depContainer?.isRegistered(ON_SIGNAL) === true) {
       const shutDown: () => Promise<void> = depContainer.resolve(ON_SIGNAL);
       await shutDown();
     }

--- a/src/redis/subscribe.ts
+++ b/src/redis/subscribe.ts
@@ -1,42 +1,10 @@
-import { readFileSync } from 'fs';
 import { Logger } from '@map-colonies/js-logger';
 import { DependencyContainer } from 'tsyringe';
 import { Producer } from 'kafkajs';
-import { createClient, RedisClientOptions } from 'redis';
 import { REDIS_SUB, SERVICES } from '../common/constants';
-import { IConfig, FeedbackResponse, GeocodingResponse, RedisConfig } from '../common/interfaces';
+import { IConfig, FeedbackResponse, GeocodingResponse } from '../common/interfaces';
 import { NotFoundError } from '../common/errors';
 import { RedisClient } from '../redis/index';
-
-const createConnectionOptions = (redisConfig: RedisConfig): Partial<RedisClientOptions> => {
-  const { host, port, enableSslAuth, sslPaths, databases, ...clientOptions } = redisConfig;
-  clientOptions.socket = { host, port };
-  if (enableSslAuth) {
-    clientOptions.socket = {
-      ...clientOptions.socket,
-      tls: true,
-      key: sslPaths.key !== '' ? readFileSync(sslPaths.key) : undefined,
-      cert: sslPaths.cert !== '' ? readFileSync(sslPaths.cert) : undefined,
-      ca: sslPaths.ca !== '' ? readFileSync(sslPaths.ca) : undefined,
-    };
-  }
-  return clientOptions;
-};
-
-export const createRedisClient = (config: IConfig, logger: Logger): RedisClient => {
-  const dbConfig = config.get<RedisConfig>('redis');
-
-  const connectionOptions = createConnectionOptions(dbConfig);
-
-  const redisClient = createClient(connectionOptions)
-    .on('error', (error: Error) => logger.error({ msg: 'redis client errored', err: error }))
-    .on('reconnecting', (...args) => logger.warn({ msg: 'redis client reconnecting', ...args }))
-    .on('end', (...args) => logger.info({ msg: 'redis client end', ...args }))
-    .on('connect', (...args) => logger.debug({ msg: 'redis client connected', ...args }))
-    .on('ready', (...args) => logger.debug({ msg: 'redis client is ready', ...args }));
-
-  return redisClient;
-};
 
 export const send = async (message: FeedbackResponse, logger: Logger, config: IConfig, kafkaProducer: Producer): Promise<void> => {
   const topic = config.get<string>('outputTopic');
@@ -66,30 +34,25 @@ export const redisSubscribe = async (deps: DependencyContainer): Promise<RedisCl
   const geocodingDB = config.get<number>('redis.databases.geocodingIndex');
   const redisTTL = config.get<number>('redis.ttl');
 
-  try {
-    await subscriber.subscribe(`__keyevent@${geocodingDB}__:set`, async (message) => {
-      logger.info(`Redis: Got new request ${message}`);
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      await ttlRedis.set(message, '', { EX: redisTTL });
-    });
+  await subscriber.subscribe(`__keyevent@${geocodingDB}__:set`, async (message) => {
+    logger.info(`Redis: Got new request ${message}`);
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    await ttlRedis.set(message, '', { EX: redisTTL });
+  });
 
-    await subscriber.subscribe(`__keyevent@${ttlDB}__:expired`, async (message: string) => {
-      let wasUsed;
-      const redisResponse = (await geocodingRedis.get(message)) as string;
-      if (redisResponse) {
-        const geocodingResponse = JSON.parse(redisResponse) as GeocodingResponse;
-        wasUsed = geocodingResponse.wasUsed;
-      }
-      if (!(wasUsed ?? false)) {
-        await sendNoChosenResult(message, logger, config, kafkaProducer, geocodingRedis);
-      }
-      await geocodingRedis.del(message);
-    });
-    return subscriber;
-  } catch (error) {
-    logger.error({ msg: `Redis Subscriber Error: ${(error as Error).message}` });
-    throw error;
-  }
+  await subscriber.subscribe(`__keyevent@${ttlDB}__:expired`, async (message: string) => {
+    let wasUsed;
+    const redisResponse = (await geocodingRedis.get(message)) as string;
+    if (redisResponse) {
+      const geocodingResponse = JSON.parse(redisResponse) as GeocodingResponse;
+      wasUsed = geocodingResponse.wasUsed;
+    }
+    if (!(wasUsed ?? false)) {
+      await sendNoChosenResult(message, logger, config, kafkaProducer, geocodingRedis);
+    }
+    await geocodingRedis.del(message);
+  });
+  return subscriber;
 };
 
 export const sendNoChosenResult = async (

--- a/src/redis/subscribe.ts
+++ b/src/redis/subscribe.ts
@@ -1,10 +1,42 @@
+import { readFileSync } from 'fs';
 import { Logger } from '@map-colonies/js-logger';
 import { DependencyContainer } from 'tsyringe';
 import { Producer } from 'kafkajs';
+import { createClient, RedisClientOptions } from 'redis';
 import { REDIS_SUB, SERVICES } from '../common/constants';
-import { IConfig, FeedbackResponse, GeocodingResponse } from '../common/interfaces';
+import { IConfig, FeedbackResponse, GeocodingResponse, RedisConfig } from '../common/interfaces';
 import { NotFoundError } from '../common/errors';
 import { RedisClient } from '../redis/index';
+
+const createConnectionOptions = (redisConfig: RedisConfig): Partial<RedisClientOptions> => {
+  const { host, port, enableSslAuth, sslPaths, databases, ...clientOptions } = redisConfig;
+  clientOptions.socket = { host, port };
+  if (enableSslAuth) {
+    clientOptions.socket = {
+      ...clientOptions.socket,
+      tls: true,
+      key: sslPaths.key !== '' ? readFileSync(sslPaths.key) : undefined,
+      cert: sslPaths.cert !== '' ? readFileSync(sslPaths.cert) : undefined,
+      ca: sslPaths.ca !== '' ? readFileSync(sslPaths.ca) : undefined,
+    };
+  }
+  return clientOptions;
+};
+
+export const createRedisClient = (config: IConfig, logger: Logger): RedisClient => {
+  const dbConfig = config.get<RedisConfig>('redis');
+
+  const connectionOptions = createConnectionOptions(dbConfig);
+
+  const redisClient = createClient(connectionOptions)
+    .on('error', (error: Error) => logger.error({ msg: 'redis client errored', err: error }))
+    .on('reconnecting', (...args) => logger.warn({ msg: 'redis client reconnecting', ...args }))
+    .on('end', (...args) => logger.info({ msg: 'redis client end', ...args }))
+    .on('connect', (...args) => logger.debug({ msg: 'redis client connected', ...args }))
+    .on('ready', (...args) => logger.debug({ msg: 'redis client is ready', ...args }));
+
+  return redisClient;
+};
 
 export const send = async (message: FeedbackResponse, logger: Logger, config: IConfig, kafkaProducer: Producer): Promise<void> => {
   const topic = config.get<string>('outputTopic');
@@ -29,29 +61,35 @@ export const redisSubscribe = async (deps: DependencyContainer): Promise<RedisCl
   const logger = deps.resolve<Logger>(SERVICES.LOGGER);
   const subscriber = deps.resolve<RedisClient>(REDIS_SUB);
 
+  logger.debug('Redis subscriber init');
   const ttlDB = config.get<number>('redis.databases.ttlIndex');
   const geocodingDB = config.get<number>('redis.databases.geocodingIndex');
   const redisTTL = config.get<number>('redis.ttl');
 
-  await subscriber.subscribe(`__keyevent@${geocodingDB}__:set`, async (message) => {
-    logger.info(`Redis: Got new request ${message}`);
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    await ttlRedis.set(message, '', { EX: redisTTL });
-  });
+  try {
+    await subscriber.subscribe(`__keyevent@${geocodingDB}__:set`, async (message) => {
+      logger.info(`Redis: Got new request ${message}`);
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      await ttlRedis.set(message, '', { EX: redisTTL });
+    });
 
-  await subscriber.subscribe(`__keyevent@${ttlDB}__:expired`, async (message: string) => {
-    let wasUsed;
-    const redisResponse = (await geocodingRedis.get(message)) as string;
-    if (redisResponse) {
-      const geocodingResponse = JSON.parse(redisResponse) as GeocodingResponse;
-      wasUsed = geocodingResponse.wasUsed;
-    }
-    if (!(wasUsed ?? false)) {
-      await sendNoChosenResult(message, logger, config, kafkaProducer, geocodingRedis);
-    }
-    await geocodingRedis.del(message);
-  });
-  return subscriber;
+    await subscriber.subscribe(`__keyevent@${ttlDB}__:expired`, async (message: string) => {
+      let wasUsed;
+      const redisResponse = (await geocodingRedis.get(message)) as string;
+      if (redisResponse) {
+        const geocodingResponse = JSON.parse(redisResponse) as GeocodingResponse;
+        wasUsed = geocodingResponse.wasUsed;
+      }
+      if (!(wasUsed ?? false)) {
+        await sendNoChosenResult(message, logger, config, kafkaProducer, geocodingRedis);
+      }
+      await geocodingRedis.del(message);
+    });
+    return subscriber;
+  } catch (error) {
+    logger.error({ msg: `Redis Subscriber Error: ${(error as Error).message}` });
+    throw error;
+  }
 };
 
 export const sendNoChosenResult = async (


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

Further  information:
Fixed the liveness issue, currently, if Redis connects properly - the app will run, and liveness will show `{status: ok}`.
If Redis does not manage to connect, the app will not work, so also `/liveness` won't be up and running.
Also fixed the redis subscriber configuration that was not correct earlier.