### PR TITLE
fix: remove redis logical db (MAPCO-6821)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Geocoding's feedback API collects usage data from the [Geocoding API](https://gi
 Checkout the OpenAPI spec [here](/openapi3.yaml)
 
 ## Workflow
-![workflow img](https://github.com/user-attachments/assets/e325dbac-933d-48fd-9143-ea8c09f23ba7)
+![workflow img](https://github.com/user-attachments/assets/63b8c7ed-4509-4dea-87ae-dc0cfc625ff9)
 
 ## How does it work?
-Once a Geocoding user searches for something using Geocoding's api, it enters Redis, and an event is triggered. This event adds to the `requestId` (from geocoding) a prefex, and adds it also to Redis with a ttl.<br/><br/>
+Once a Geocoding user searches for something using Geocoding's api, it enters Redis, and an event is triggered. This event adds to the `requestId` (from geocoding) a prefix, and adds it also to Redis with a ttl.<br/><br/>
 When the Geocoding user chooses a result, the requesting system will then send the `request_id`, the `chosen_response_id`, and the `user_id` back to us using the [Feedback api](/openapi3.yaml).<br/>
 Once we get the chosen response from the api, we validate it and make sure it exists in the Redis, and once it is validated we add a `wasUsed = true` parameter to the geocoding response (in Redis) for later use. We then send the response to Kafka (where it will later be enriched and added to elastic -> see [Geocoding Enrichment](https://github.com/MapColonies/geocoding-enrichment) for more details).<br/>
 Once the TTL of the `requestId` expires an even is triggered, and there are two options:<br/>

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Geocoding's feedback API collects usage data from the [Geocoding API](https://gi
 Checkout the OpenAPI spec [here](/openapi3.yaml)
 
 ## Workflow
-![workflow img](https://github.com/user-attachments/assets/7ed767ad-02dd-46f3-9de7-d2be72205e2c)
+![workflow img](https://github.com/user-attachments/assets/e325dbac-933d-48fd-9143-ea8c09f23ba7)
 
 ## How does it work?
-Once a Geocoding user searches for something using Geocoding's api, it enters Redis (in the geocoding DB index), and an event is triggered. This event adds the `requestId` (from geocoding) to a different Redis DB with a ttl of 5 minutes (TTL DB index).<br/><br/>
+Once a Geocoding user searches for something using Geocoding's api, it enters Redis, and an event is triggered. This event adds to the `requestId` (from geocoding) a prefex, and adds it also to Redis with a ttl.<br/><br/>
 When the Geocoding user chooses a result, the requesting system will then send the `request_id`, the `chosen_response_id`, and the `user_id` back to us using the [Feedback api](/openapi3.yaml).<br/>
-Once we get the chosen response from the api, we validate it and make sure it exists in the Redis geocoding DB, and once it is validated we add a `wasUsed = true` parameter to the geocoding response (in Redis) for later use. We then send the response to Kafka (where it will later be enriched and added to elastic -> see [Geocoding Enrichment](https://github.com/MapColonies/geocoding-enrichment) for more details).<br/>
+Once we get the chosen response from the api, we validate it and make sure it exists in the Redis, and once it is validated we add a `wasUsed = true` parameter to the geocoding response (in Redis) for later use. We then send the response to Kafka (where it will later be enriched and added to elastic -> see [Geocoding Enrichment](https://github.com/MapColonies/geocoding-enrichment) for more details).<br/>
 Once the TTL of the `requestId` expires an even is triggered, and there are two options:<br/>
 1. One or more responses were chosen.
 2. No response was chosen (only searched for).

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -56,9 +56,9 @@
       "key": "REDIS_KEY_PATH",
       "cert": "REDIS_CERT_PATH"
     },
-    "databases": {
-      "geocodingIndex": "REDIS_GEOCODING_INDEX",
-      "ttlIndex": "REDIS_TTL_INDEX"
+    "database": {
+      "__name": "REDIS_DATABASE",
+      "__format": "number"
     },
     "ttl": {
       "__name": "REDIS_TTL",

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -56,10 +56,6 @@
       "key": "REDIS_KEY_PATH",
       "cert": "REDIS_CERT_PATH"
     },
-    "database": {
-      "__name": "REDIS_DATABASE",
-      "__format": "number"
-    },
     "ttl": {
       "__name": "REDIS_TTL",
       "__format": "number"

--- a/config/default.json
+++ b/config/default.json
@@ -36,7 +36,6 @@
       "key": "",
       "cert": ""
     },
-    "database": 0,
     "ttl": 300
   },
   "kafka": {

--- a/config/default.json
+++ b/config/default.json
@@ -36,10 +36,7 @@
       "key": "",
       "cert": ""
     },
-    "databases": {
-      "geocodingIndex": 0,
-      "ttlIndex": 1
-    },
+    "database": 0,
     "ttl": 300
   },
   "kafka": {

--- a/config/test.json
+++ b/config/test.json
@@ -10,14 +10,11 @@
       "key": "",
       "cert": ""
     },
-    "databases": {
-      "geocodingIndex": 2,
-      "ttlIndex": 3
-    },
+    "database": 1,
     "ttl": 2
   },
   "kafka": {
-    "brokers": "kafka:9092"
+    "brokers": "localhost:9092"
   },
   "kafkaConsumer": {},
   "kafkaProducer": {},

--- a/config/test.json
+++ b/config/test.json
@@ -10,7 +10,6 @@
       "key": "",
       "cert": ""
     },
-    "database": 1,
     "ttl": 2
   },
   "kafka": {

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -21,7 +21,6 @@ data:
   
   {{- with .Values.redisConfig }}
   REDIS_HOST: {{ .host }}
-  REDIS_DATABASE: {{ .database | quote}}
   REDIS_PORT: {{ .port | quote }}
   {{- if .sslAuth.enabled }}
   REDIS_ENABLE_SSL_AUTH: "true"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -75,7 +75,6 @@ redisConfig:
   host: localhost
   username: ""
   password: ""
-  database: 0
   port: 6379
   sslAuth:
     enabled: false

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -12,8 +12,7 @@ export const SERVICES = {
   CONFIG: Symbol('Config'),
   TRACER: Symbol('Tracer'),
   METER: Symbol('Meter'),
-  GEOCODING_REDIS: Symbol('GeocodingRedis'),
-  TTL_REDIS: Symbol('TTLRedis'),
+  REDIS: Symbol('Redis'),
   KAFKA: Symbol('Kafka'),
 } satisfies Record<string, symbol>;
 /* eslint-enable @typescript-eslint/naming-convention */

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -18,7 +18,6 @@ export type RedisConfig = {
   port: number;
   enableSslAuth: boolean;
   sslPaths: { ca: string; cert: string; key: string };
-  databases: { geocodingIndex: number; ttlIndex: number };
 } & RedisClientOptions;
 
 export type KafkaOptions = {

--- a/src/redis/subscribe.ts
+++ b/src/redis/subscribe.ts
@@ -6,7 +6,7 @@ import { IConfig, FeedbackResponse, GeocodingResponse } from '../common/interfac
 import { NotFoundError } from '../common/errors';
 import { RedisClient } from '../redis/index';
 
-const REDIS_PREFIX = 'ttl_';
+const TTL_PREFIX = 'ttl_';
 
 export const send = async (message: FeedbackResponse, logger: Logger, config: IConfig, kafkaProducer: Producer): Promise<void> => {
   const topic = config.get<string>('outputTopic');
@@ -31,21 +31,20 @@ export const redisSubscribe = async (deps: DependencyContainer): Promise<RedisCl
   const subscriber = deps.resolve<RedisClient>(REDIS_SUB);
 
   logger.debug('Redis subscriber init');
-  const redisIndex = config.get<number>('redis.database');
   const redisTTL = config.get<number>('redis.ttl');
 
-  await subscriber.subscribe(`__keyevent@${redisIndex}__:set`, async (message) => {
-    if (!message.startsWith(REDIS_PREFIX)) {
+  await subscriber.subscribe(`__keyevent@0__:set`, async (message) => {
+    if (!message.startsWith(TTL_PREFIX)) {
       logger.info(`Redis: Got new request ${message}`);
-      const ttlMessage = REDIS_PREFIX + message;
+      const ttlMessage = TTL_PREFIX + message;
       // eslint-disable-next-line @typescript-eslint/naming-convention
       await redisClient.set(ttlMessage, '', { EX: redisTTL });
     }
   });
 
-  await subscriber.subscribe(`__keyevent@${redisIndex}__:expired`, async (message: string) => {
-    if (message.startsWith(REDIS_PREFIX)) {
-      const geocodingMessage = message.substring(REDIS_PREFIX.length);
+  await subscriber.subscribe(`__keyevent@0__:expired`, async (message: string) => {
+    if (message.startsWith(TTL_PREFIX)) {
+      const geocodingMessage = message.substring(TTL_PREFIX.length);
 
       let wasUsed;
       const redisResponse = (await redisClient.get(geocodingMessage)) as string;

--- a/tests/integration/docs/docs.spec.ts
+++ b/tests/integration/docs/docs.spec.ts
@@ -16,8 +16,7 @@ describe('docs', function () {
       override: [
         { token: SERVICES.LOGGER, provider: { useValue: jsLogger({ enabled: false }) } },
         { token: SERVICES.TRACER, provider: { useValue: trace.getTracer('testTracer') } },
-        { token: SERVICES.GEOCODING_REDIS, provider: { useValue: {} } },
-        { token: SERVICES.TTL_REDIS, provider: { useValue: {} } },
+        { token: SERVICES.REDIS, provider: { useValue: {} } },
         { token: REDIS_SUB, provider: { useValue: {} } },
         { token: SERVICES.KAFKA, provider: { useValue: {} } },
       ],


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✔                                                                        |
| Deprecations    | ✔                                                                        |
| Documentation   | ✔                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

Further  information:
Our previous logic used Redis logical databases, but when we tried it with Redis Enterprise, it did not work, since Redis Enterprise does not support logical databases within an existing database.
So instead of logical databases, we used prefixes.  
